### PR TITLE
Support for .m files

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 79

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
+ignore = E731
 max-line-length = 79

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -19,9 +19,16 @@ jobs:
     - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.8 
+        python-version: 3.8
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8
     - name: Run Test
       run: |
         export PYTHONPATH="${PYTHONPATH}:/home/runner/work/FileSigner/FileSigner"
         cd test
         python test.py
+    - name: Lint with flake8
+      run: |
+        flake8

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 *__pycache__*
 *.pyc
+
+# ide generated files
+.idea/

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The signature is in form of your name and a timestamp of when the file was creat
   
 # Supported files types
 ```
-{py,java,js,c,php,kt,go,pl,rb,xml,cofee,css,html,dart}
+{py,java,js,c,php,kt,go,pl,rb,xml,cofee,css,html,dart,r,m}
 ```
 
 # How to contribute

--- a/app/app.py
+++ b/app/app.py
@@ -1,4 +1,3 @@
-
 import argparse
 import signer
 from os import getcwd

--- a/main.py
+++ b/main.py
@@ -1,10 +1,13 @@
-
 import argparse
 import signer
 
-argParser = argparse.ArgumentParser(description="Prepend Signature to Files") 
-argParser.add_argument('--dir_path', type=str, help='Path to the directory whose files are to be signed')
+argParser = argparse.ArgumentParser(description="Prepend Signature to Files")
+argParser.add_argument(
+    '--dir_path',
+    type=str,
+    help='Path to the directory whose files are to be signed',
+)
 argParser.add_argument('--author', type=str, help="Full name of file owner")
 args = argParser.parse_args()
 
-signer.Sign(args.dir_path, args.author) 
+signer.Sign(args.dir_path, args.author)

--- a/signer.py
+++ b/signer.py
@@ -3,26 +3,26 @@ import time
 from symbols import symbols
 import platform
 
-
-
-# Get File extension 
-getExtension = lambda fileName : fileName.split('.')[-1]
+# Get File extension
+getExtension = lambda fileName: fileName.split('.')[-1]
 
 # Check if a file has extension
-hasExtension = lambda fileName : len(fileName.split('.'))>0
+hasExtension = lambda fileName: len(fileName.split('.')) > 0
+
 
 # Get the time a file was created
-def createdAt(filePath): 
-    # We can get the time the file is created on Windows but only last modified time on linux
+def createdAt(filePath):
+    # We can get the time the file is created on Windows
+    # but only last modified time on linux
     if platform.system() in ('Windows', 'Linux'):
         return time.ctime(path.getctime(filePath))
     else:
         # we are on Mac Os, we can get the time the file was created
         return time.ctime(stat(filePath).st_birthtime)
 
+
 # Generates signature content
 def generateSignature(symbol, name, date):
-
     signature_one = "{open}\n**\n * author :   \t{name}\n * created : \t{date}\n**\n{close}\n"
 
     signature_mul = "{open}\n{open}**\n{open} * author :   \t{name}\n{open} * created : \t{date}\n{open}**\n{close}\n"
@@ -36,16 +36,19 @@ def generateSignature(symbol, name, date):
         return signature_one.format(open=symbol[0], close=symbol[1], name=name, date=date)
 
 
-# Checks if file has already been signed before 
+# Checks if file has already been signed before
 def fileAlreadySigned(contents, signature):
-    return signature[0:40] in contents[0:50]  #checking 0-50th index of the string instead of the whole string, to increase search time
+    return signature[0:40] in contents[
+                              0:50]  # checking 0-50th index of the string instead of the whole string, to increase search time
+
+
 # Signs a file
-def signFile(filePath, symbol, author): 
+def signFile(filePath, symbol, author):
     date = createdAt(filePath)
     signature = generateSignature(symbol, author, date)
     f = open(filePath, 'r')
     contents = f.readlines()
- 
+
     if not fileAlreadySigned(''.join(contents).lstrip(), signature):
         contents.insert(0, signature)
         f.close()
@@ -53,7 +56,7 @@ def signFile(filePath, symbol, author):
             f.write(''.join(contents))
         print("File successfully signed")
 
-        #R code block
+        # R code block
     elif not fileAlreadySigned(''.join(contents)):
         contents.insert(0, signature)
         f.close()
@@ -61,31 +64,32 @@ def signFile(filePath, symbol, author):
             f.write(''.join(contents))
             print("File already signed before")
 
+
 # Get comment symbol based on file extension
-def getSymbol(extension): 
+def getSymbol(extension):
     return symbols[extension]
+
 
 def Sign(dir_path, author, *args):
     # check that argument specified is a valid file or directory
-    assert(path.isdir(dir_path) or path.isfile(dir_path)), "You have to specify a directory by setting --dir_path"
+    assert (path.isdir(dir_path) or path.isfile(dir_path)), "You have to specify a directory by setting --dir_path"
     # check that there are files presents in the specified directory
     if path.isdir(dir_path):
-        assert(len(listdir(dir_path)) > 0), "No files to sign here"
+        assert (len(listdir(dir_path)) > 0), "No files to sign here"
 
     # signing a file
     if path.isfile(dir_path):
         symbol = getSymbol(getExtension(dir_path))
         if symbol:
-            signFile(dir_path, symbol,author)
+            signFile(dir_path, symbol, author)
         else:
             print("Oops! File type not supported")
-    #signing files in a folder
+    # signing files in a folder
     else:
         for file in listdir(dir_path):
             symbol = getSymbol(getExtension(file))
             filePath = dir_path + "/" + file
             if symbol and path.isfile(filePath):
-                signFile(filePath, symbol,author)
+                signFile(filePath, symbol, author)
             else:
                 print("Oops! File type not supported or Encountered a folder")
-

--- a/signer.py
+++ b/signer.py
@@ -23,23 +23,39 @@ def createdAt(filePath):
 
 # Generates signature content
 def generateSignature(symbol, name, date):
-    signature_one = "{open}\n**\n * author :   \t{name}\n * created : \t{date}\n**\n{close}\n"
+    signature_one = "{open}\n**\n * author :   " \
+                    "\t{name}\n * created : " \
+                    "\t{date}\n**\n{close}\n"
 
-    signature_mul = "{open}\n{open}**\n{open} * author :   \t{name}\n{open} * created : \t{date}\n{open}**\n{close}\n"
+    signature_mul = "{open}\n{open}**\n{open} * author :   " \
+                    "\t{name}\n{open} * created : " \
+                    "\t{date}\n{open}**\n{close}\n"
 
     if symbol[2]:
 
-        return signature_mul.format(open=symbol[0], close=symbol[1], name=name, date=date)
+        return signature_mul.format(open=symbol[0],
+                                    close=symbol[1],
+                                    name=name,
+                                    date=date,
+                                    )
 
     else:
 
-        return signature_one.format(open=symbol[0], close=symbol[1], name=name, date=date)
+        return signature_one.format(open=symbol[0],
+                                    close=symbol[1],
+                                    name=name,
+                                    date=date,)
 
 
 # Checks if file has already been signed before
 def fileAlreadySigned(contents, signature):
-    return signature[0:40] in contents[
-                              0:50]  # checking 0-50th index of the string instead of the whole string, to increase search time
+    """
+    checking 0-50th index of the string instead of the whole string,
+    to increase search time
+    :param contents:
+    :param signature:
+    """
+    return signature[0:40] in contents[0:50]
 
 
 # Signs a file
@@ -72,7 +88,8 @@ def getSymbol(extension):
 
 def Sign(dir_path, author, *args):
     # check that argument specified is a valid file or directory
-    assert (path.isdir(dir_path) or path.isfile(dir_path)), "You have to specify a directory by setting --dir_path"
+    assert (path.isdir(dir_path) or path.isfile(dir_path)), \
+        "You have to specify a directory by setting --dir_path"
     # check that there are files presents in the specified directory
     if path.isdir(dir_path):
         assert (len(listdir(dir_path)) > 0), "No files to sign here"

--- a/symbols.py
+++ b/symbols.py
@@ -19,5 +19,6 @@ symbols = {"py": ('"""', '"""', False),
            "R": ('#', '#', True),
            "scala": ('"""', '"""', False),
            "swift": ('"""', '"""', False),
-           "cs": ('@"', '"', False)
+           "cs": ('@"', '"', False),
+           "m": ('%{', '%}', False)
            }

--- a/symbols.py
+++ b/symbols.py
@@ -1,25 +1,23 @@
+# True==>Doesn't support multiline comments
 
-#True==>Doesn't support multiline comments
+# False==>Supports multiline comments
 
-#False==>Supports multiline comments
-
-symbols = {"py": ('"""','"""',False),
-            "java": ('/*','*/',False),
-            "js": ('/*','*/',False),
-            "c": ('/*','*/',False),
-            "php": ('/*','*/',False),
-            "kt": ('/*','*/',False),
-            "go": ('/*','*/',False),
-            "pl": ('/*','*/',False),
-            "rb": ('=','=',False),
-            "xml": ('<!--','-->',False),
-            "cofee": ('###','###',False),
-            "css": ('/*','*/',False),
-            "html": ('<!--','-->',False),
-            "dart": ('/*','*/',False),
-            "R" :('#','#',True),
-           "scala": ('"""', '"""',False),
-           "swift": ('"""', '"""',False),
-           "cs": ('@"', '"',False)
+symbols = {"py": ('"""', '"""', False),
+           "java": ('/*', '*/', False),
+           "js": ('/*', '*/', False),
+           "c": ('/*', '*/', False),
+           "php": ('/*', '*/', False),
+           "kt": ('/*', '*/', False),
+           "go": ('/*', '*/', False),
+           "pl": ('/*', '*/', False),
+           "rb": ('=', '=', False),
+           "xml": ('<!--', '-->', False),
+           "cofee": ('###', '###', False),
+           "css": ('/*', '*/', False),
+           "html": ('<!--', '-->', False),
+           "dart": ('/*', '*/', False),
+           "R": ('#', '#', True),
+           "scala": ('"""', '"""', False),
+           "swift": ('"""', '"""', False),
+           "cs": ('@"', '"', False)
            }
-

--- a/test/sample/sample.m
+++ b/test/sample/sample.m
@@ -1,2 +1,2 @@
-classdef Sample
+classdef sample
 end

--- a/test/sample/sample.m
+++ b/test/sample/sample.m
@@ -1,0 +1,2 @@
+classdef Sample
+end

--- a/test/test.py
+++ b/test/test.py
@@ -4,15 +4,19 @@ import signer
 import symbols
 from random import randint
 
+
 class AppTests(unittest.TestCase):
     """
-    Ensure to add the project to PYTHON_PATH in order to make the package visible to this test file
+    Ensure to add the project to PYTHON_PATH
+    in order to make the package visible to this test file
     Also, make sure you run this test from the test directory
     """
+
     def test_sign(self):
 
         def randomName():
-            return "".join("abcdefghijklmnopqrstuvwxyz"[randint(0,100)%26] for i in range(5))
+            return "".join("abcdefghijklmnopqrstuvwxyz"
+                           [randint(0, 100) % 26] for i in range(5))
 
         # current working directory must be the /test directory
         pathToTestFile = os.path.join(os.getcwd() + "/sample/")
@@ -20,19 +24,20 @@ class AppTests(unittest.TestCase):
 
         for file in samplefiles:
             # Lets deal with files
-            if len(file.split("."))>0 and file.split(".")[-1] in symbols.symbols:
+            if len(file.split(".")) > 0 and \
+                    file.split(".")[-1] in symbols.symbols:
                 with open(pathToTestFile + file, "r") as f:
                     # keep the old file contents before signing
                     oldContent = f.read()
                 author = randomName()
                 # sign test files
-                signer.Sign(pathToTestFile+file, author)
-                with open(pathToTestFile+file, "r") as f:
+                signer.Sign(pathToTestFile + file, author)
+                with open(pathToTestFile + file, "r") as f:
                     self.assertTrue(author in f.read())
                 # write back the old file contents after signing
                 with open(pathToTestFile + file, "w") as f:
                     f.write(oldContent)
 
+
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
- Added lint test to GitHub actions
- Refactored to match PEP8 style, passing the lint test
- Silenced **Do not assign a lambda expression, use a def (E731)** as this is part of the core functionality.
        - To reproduce locally, remove the line `ignore = E731` in .flake8 file
- Added support for .m files